### PR TITLE
Fix compile error on 4.10

### DIFF
--- a/Source/SublimeTextSourceCodeAccess/Private/SublimeTextSourceCodeAccessor.h
+++ b/Source/SublimeTextSourceCodeAccess/Private/SublimeTextSourceCodeAccessor.h
@@ -27,6 +27,7 @@ class FSublimeTextSourceCodeAccessor : public ISourceCodeAccessor
 {
 public:
     /** ISourceCodeAccessor implementation */
+    virtual void RefreshAvailability() override { };
     virtual bool CanAccessSourceCode() const override;
     virtual FName GetFName() const override;
     virtual FText GetNameText() const override;

--- a/Source/SublimeTextSourceCodeAccess/Private/SublimeTextSourceCodeAccessor.h
+++ b/Source/SublimeTextSourceCodeAccess/Private/SublimeTextSourceCodeAccessor.h
@@ -27,7 +27,7 @@ class FSublimeTextSourceCodeAccessor : public ISourceCodeAccessor
 {
 public:
     /** ISourceCodeAccessor implementation */
-    virtual void RefreshAvailability() override { };
+    virtual void RefreshAvailability() override { }
     virtual bool CanAccessSourceCode() const override;
     virtual FName GetFName() const override;
     virtual FText GetNameText() const override;

--- a/SublimeTextSourceCodeAccess.uplugin
+++ b/SublimeTextSourceCodeAccess.uplugin
@@ -5,7 +5,7 @@
     "VersionName" : "1.0",
     "CreatedBy" : "Felix Laurie von Massenbach",
     "CreatedByURL" : "http://erbridge.co.uk/",
-    "EngineVersion" : "4.7.3",
+    "EngineVersion" : "4.10",
     "Description" : "Allows access to source code with Sublime Text.",
     "Category" : "Developer.Source Code Access",
     "EnabledByDefault" : true,


### PR DESCRIPTION
When compiling UE4Editor v4.10, I get the following error:

```
[602/792] Compile Module.SublimeTextSourceCodeAccess.cpp
In file included from /mnt/data/home/caleb/Downloads/UnrealEngineTest/Engine/Plugins/Developer/SublimeTextSourceCodeAccess/Intermediate/Build/Linux/x86_64-unknown-linux-gnu/UE4Editor/Development/SublimeTextSourceCodeAccess/Module.SublimeTextSourceCodeAccess.cpp:2:
In file included from /mnt/data/home/caleb/Downloads/UnrealEngineTest/Engine/Plugins/Developer/SublimeTextSourceCodeAccess/Source/SublimeTextSourceCodeAccess/Private/SublimeTextSourceCodeAccessModule.cpp:24:
/mnt/data/home/caleb/Downloads/UnrealEngineTest/Engine/Plugins/Developer/SublimeTextSourceCodeAccess/Source/SublimeTextSourceCodeAccess/Private/SublimeTextSourceCodeAccessModule.h:35:36: error: field type 'FSublimeTextSourceCodeAccessor' is an abstract class
    FSublimeTextSourceCodeAccessor SublimeTextSourceCodeAccessor;
                                   ^
Developer/SourceCodeAccess/Public/ISourceCodeAccessor.h:18:15: note: unimplemented pure virtual method 'RefreshAvailability' in 'FSublimeTextSourceCodeAccessor'
        virtual void RefreshAvailability() = 0;
                     ^
In file included from /mnt/data/home/caleb/Downloads/UnrealEngineTest/Engine/Plugins/Developer/SublimeTextSourceCodeAccess/Intermediate/Build/Linux/x86_64-unknown-linux-gnu/UE4Editor/Development/SublimeTextSourceCodeAccess/Module.SublimeTextSourceCodeAccess.cpp:2:
/mnt/data/home/caleb/Downloads/UnrealEngineTest/Engine/Plugins/Developer/SublimeTextSourceCodeAccess/Source/SublimeTextSourceCodeAccess/Private/SublimeTextSourceCodeAccessModule.cpp:26:1: error: cannot initialize return object of type 'IModuleInterface *' with an rvalue of type 'FSublimeTextSourceCodeAccessModule *'
IMPLEMENT_MODULE( FSublimeTextSourceCodeAccessModule, SublimeTextSourceCodeAccess );
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Runtime/Core/Public/Modules/ModuleManager.h:683:11: note: expanded from macro 'IMPLEMENT_MODULE'
                        return new ModuleImplClass(); \
                               ^~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```

`ISourceCodeAccessor` appears to have a new unimplemented virtual method:

``` cpp
virtual void RefreshAvailability() = 0;
```

The `NullSourceCodeAccess` implementation simply defines the method as:

``` cpp
virtual void RefreshAvailability() override { }
```

Adding this method to `FSublimeTextSourceCodeAccessor` fixes the issue, and compiles properly. NOTE: This fix will likely cause SublimeTextSourceCodeAccess to fail to compile on earlier versions of UE4Editor because the new method is overridden.
