### PR TITLE
Fixed compile errors for unreal 4.15

### DIFF
--- a/Source/SublimeTextSourceCodeAccess/Private/SublimeTextSourceCodeAccessModule.cpp
+++ b/Source/SublimeTextSourceCodeAccess/Private/SublimeTextSourceCodeAccessModule.cpp
@@ -19,9 +19,9 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
+#include "SublimeTextSourceCodeAccessModule.h"
 #include "SublimeTextSourceCodeAccessPrivatePCH.h"
 #include "Runtime/Core/Public/Features/IModularFeatures.h"
-#include "SublimeTextSourceCodeAccessModule.h"
 
 IMPLEMENT_MODULE( FSublimeTextSourceCodeAccessModule, SublimeTextSourceCodeAccess );
 

--- a/Source/SublimeTextSourceCodeAccess/Private/SublimeTextSourceCodeAccessor.cpp
+++ b/Source/SublimeTextSourceCodeAccess/Private/SublimeTextSourceCodeAccessor.cpp
@@ -19,8 +19,8 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
-#include "SublimeTextSourceCodeAccessPrivatePCH.h"
 #include "SublimeTextSourceCodeAccessor.h"
+#include "SublimeTextSourceCodeAccessPrivatePCH.h"
 #include "DesktopPlatformModule.h"
 
 #define LOCTEXT_NAMESPACE "SublimeTextSourceCodeAccessor"


### PR DESCRIPTION
Originally got a compile error from this plugin when attempting to compile unreal engine with this plugin active. 